### PR TITLE
fail if python version is < 3.5

### DIFF
--- a/orca-build
+++ b/orca-build
@@ -31,6 +31,10 @@ import subprocess
 
 __version__ = "<unknown-version>"
 
+if sys.version_info < (3, 5):
+	print("python >= 3.5 is needed to run orca-build")
+	sys.exit(1)
+
 class attrdict(object):
 	"Dumb implementation of attrdict."
 	def __init__(self, *args, **kwargs):


### PR DESCRIPTION
python >= 3.5 is needed for  json.decoder.JSONDecodeError

fkoch@linux-bhu4:~/projects/tmp> orca-build -t a  .
Traceback (most recent call last):
  File "/usr/bin/orca-build", line 296, in parse
    args = json.loads(rest.strip())
  File "/usr/lib64/python3.4/json/__init__.py", line 318, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python3.4/json/decoder.py", line 343, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python3.4/json/decoder.py", line 361, in raw_decode
    raise ValueError(errmsg("Expecting value", s, err.value)) from None
ValueError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/orca-build", line 742, in <module>
    __wrapped_main__()
  File "/usr/bin/orca-build", line 740, in __wrapped_main__
    main(ctx, config)
  File "/usr/bin/orca-build", line 705, in main
    builder = Builder(ctx, build_args=config.build_args, rootless=config.rootless)
  File "/usr/bin/orca-build", line 356, in __init__
    self.script = DockerfileParser(contents).parse()
  File "/usr/bin/orca-build", line 297, in parse
    except json.decoder.JSONDecodeError:
AttributeError: 'module' object has no attribute 'JSONDecodeError'